### PR TITLE
fix .rss and .* types to call callbacks correctly (set err to null, and f

### DIFF
--- a/lib/carto/external.js
+++ b/lib/carto/external.js
@@ -165,6 +165,7 @@ External.mkdirp = function mkdirP(p, mode, f) {
 };
 
 External.types = [
+    //for datafile: function(d, c) - d is an External object, c is a function taking (err, filename)
     {
         extension: /\.zip/,
         datafile: function(d, c) { d.findOneByExtension('.shp', c); },
@@ -218,7 +219,7 @@ External.types = [
     },
     {
         extension: /\.rss/,
-        datafile: function(d, c) { c(d.path()); },
+        datafile: function(d, c) { c(null, d.path()); },
         ds_options: {
             type: 'ogr',
             layer_by_index: 0
@@ -226,7 +227,7 @@ External.types = [
     },
     {
         extension: /.*/g,
-        datafile: function(d, c) { c(d.path()); }
+        datafile: function(d, c) { c(null, d.path()); }
     }
 ];
 


### PR DESCRIPTION
fix .rss and .\* types to call callbacks correctly (set err to null, and filename to the second argument)
