### PR TITLE
Data-driven carto parameters called out

### DIFF
--- a/index.html
+++ b/index.html
@@ -563,7 +563,7 @@
         
       </small>
       
-      <div class='description'>The height of the marker, if using one of the default types.</div>
+      <div class='description'>The height of the marker, if using one of the default types. <i>Can be data-driven: </i>Data columns containing size information are specified using brackets like [column_name]</div>
       </li>
   
       <li id='section-8-marker-height'><div>
@@ -580,7 +580,7 @@
         
       </small>
       
-      <div class='description'>The height of the marker, if using one of the default types.</div>
+      <div class='description'>The height of the marker, if using one of the default types. <i>Can be data-driven: </i>Data columns containing size information are specified using brackets like [column_name]</div>
       </li>
   
       <li id='section-9-marker-fill'><div>
@@ -682,7 +682,7 @@
         <span class='description'>(no transformation)</span>
       </small>
       
-      <div class='description'>An SVG transformation definition</div>
+      <div class='description'>An SVG transformation definition.  <i>Can be data-driven: </i>Data columns containing rescaling information are specified using brackets like [column_name]</div>
       </li>
   
   </ul>
@@ -701,7 +701,7 @@
         </small>
       </div>
       
-      <div class='description'>Value to use for a shield"s text label. Data columns are specified using brackets like [column_name]</div>
+      <div class='description'>Value to use for a shield"s text label. <i>Can be data-driven: </i>Data columns are specified using brackets like [column_name]</div>
       </li>
   
       <li id='section-1-shield-face-name'><div>
@@ -1444,7 +1444,7 @@
         <span class='description'>(No transformation)</span>
       </small>
       
-      <div class='description'>SVG transformation definition</div>
+      <div class='description'>SVG transformation definition.  <i>Can be data-driven: </i>Data columns containing rescaling information are specified using brackets like [column_name]</div>
       </li>
   
   </ul>
@@ -1468,7 +1468,7 @@
         
       </small>
       
-      <div class='description'>Value to use for a text label. Data columns are specified using brackets like [column_name]</div>
+      <div class='description'>Value to use for a text label. <i>Can be data-driven: </i>Data columns containing label text are specified using brackets like [column_name]</div>
       </li>
   
       <li id='section-1-text-face-name'><div>
@@ -1838,7 +1838,7 @@
         </small>
       </div>
       
-      <div class='description'>Rotate the text.</div>
+      <div class='description'>Rotate the text.  <i>Can be data-driven: </i>Data columns containing angles (0-360) are specified using brackets like [column_name]</div>
       </li>
   
       <li id='section-24-text-placement'><div>
@@ -2022,7 +2022,7 @@
         
       </small>
       
-      <div class='description'>The height of the building in pixels.</div>
+      <div class='description'>The height of the building in pixels. <i>Can be data-driven: </i>Data columns containing height information are specified using brackets like [column_name]</div>
       </li>
   
   </ul>


### PR DESCRIPTION
Just updating the carto docs to flag the parameters that can be populated from data fields. Only description text has been updated, though it might be nice to have a docs section, tutorial or blog post about [the full list](https://gist.github.com/3229978).
