### PR TITLE
Throw an exception when an unsupported mapnik version is requested

### DIFF
--- a/lib/carto/tree/reference.js
+++ b/lib/carto/tree/reference.js
@@ -14,6 +14,7 @@ tree.Reference = {
 };
 
 tree.Reference.setVersion = function(version) {
+    if ( ! mapnik_reference.version.hasOwnProperty(version) ) throw new Error("Unsupported mapnik version " + version);
     tree.Reference.data = mapnik_reference.version[version];
 };
 


### PR DESCRIPTION
The alternative is to get all kind of syntax errors while trying to reference obviously unexisting members of "undefined". Throwing in the Renderer constructor seems cleaner to me.
