### PR TITLE
Error out on unsupported mapnik version

### DIFF
--- a/lib/carto/renderer.js
+++ b/lib/carto/renderer.js
@@ -22,10 +22,9 @@ carto.Renderer.prototype.render = function render(m, callback) {
         effects: []
     });
 
-    try {
-      tree.Reference.setVersion(this.options.mapnik_version)
-    } catch (err) {
-      callback(err, null);
+    if ( ! tree.Reference.setVersion(this.options.mapnik_version) ) {
+      callback(new Error("Could not set mapnik version to " + this.options.mapnik_version), null);
+      return;
     }
 
     var output = [];

--- a/lib/carto/tree/reference.js
+++ b/lib/carto/tree/reference.js
@@ -13,9 +13,15 @@ tree.Reference = {
     data: mapnik_reference.version.latest
 };
 
+/// @param version target mapnik version
+/// @return true on success, false on error (unsupported mapnik version)
 tree.Reference.setVersion = function(version) {
-    if ( ! mapnik_reference.version.hasOwnProperty(version) ) throw new Error("Unsupported mapnik version " + version);
-    tree.Reference.data = mapnik_reference.version[version];
+    if ( mapnik_reference.version.hasOwnProperty(version) ) {
+      tree.Reference.data = mapnik_reference.version[version];
+      return true;
+    } else {
+      return false;
+    }
 };
 
 tree.Reference.required_prop_list_cache = {};


### PR DESCRIPTION
It still throws internally, but catches it from render() converting to user callback.

There's another thrower in lib/carto/tree/zoom.js so doesn't seem a forbidden practice
