### PR TITLE
Catch parser exceptions (it does throw!)

### DIFF
--- a/lib/carto/renderer.js
+++ b/lib/carto/renderer.js
@@ -29,6 +29,7 @@ carto.Renderer.prototype.render = function render(m, callback) {
     var output = [];
 
     // Transform stylesheets into rulesets.
+    try { // Parser may throw
     var rulesets = _(m.Stylesheet).chain()
         .map(function(s) {
             // Passing the environment from stylesheet to stylesheet,
@@ -36,15 +37,14 @@ carto.Renderer.prototype.render = function render(m, callback) {
             env = _(env).extend({filename:s.id});
 
             var time = +new Date();
-            // Parser may throw
-            try { root = (carto.Parser(env)).parse(s.data); }
-            catch (err) { callback(err, null); return; }
+                root = (carto.Parser(env)).parse(s.data);
             if (env.benchmark)
                 console.warn('Parsing time: ' + (new Date() - time) + 'ms');
             return root.toList(env);
         })
         .flatten()
         .value();
+    } catch (err) { callback(err, null); return; }
 
     // Iterate through layers and create styles custom-built
     // for each of them, and apply those styles to the layers.


### PR DESCRIPTION
Renderer fails to callback on parsing error, without this.
Was also a TODO item in the code
