### PR TITLE
Remove legacy comment

### DIFF
--- a/lib/carto/tree/ruleset.js
+++ b/lib/carto/tree/ruleset.js
@@ -53,14 +53,6 @@ tree.Ruleset.prototype = {
     variable: function(name) {
         return this.variables()[name];
     },
-    /**
-     * Extend this rule by adding rules from another ruleset
-     *
-     * Currently this is designed to accept less specific
-     * rules and add their values only if this ruleset doesn't
-     * contain them.
-     */
-
     rulesets: function() {
         if (this._rulesets) { return this._rulesets; }
         else {


### PR DESCRIPTION
Remove the comment for the extend method, which was removed back in 7c81eb353dcea
