### PR TITLE
Include the instance name in the rule id (fixes #177)

### DIFF
--- a/lib/carto/tree/rule.js
+++ b/lib/carto/tree/rule.js
@@ -26,7 +26,7 @@ tree.Rule.prototype.clone = function() {
 };
 
 tree.Rule.prototype.updateID = function() {
-    return this.id = this.zoom + '#' + this.name;
+    return this.id = this.zoom + '#' + this.instance + '#' + this.name;
 };
 
 tree.Rule.prototype.toString = function() {


### PR DESCRIPTION
This fixes #177. The addRules method of definition.js checks rule inheritance using the id of the rule, and only adds rules from ancestors if the id is different. However, without this patch, foo/line-color and bar/line-color have the same id and therefore aren't recognised as applying to different instances.
