### PR TITLE
Experimental shorthand support.

### DIFF
--- a/lib/carto/parser.js
+++ b/lib/carto/parser.js
@@ -711,8 +711,9 @@ carto.Parser = function Parser(env) {
                         var rs = new tree.Ruleset(selectors, rules);
                         rs.isMap = true;
                         return rs;
+                    } else {
+                        return new tree.Ruleset(selectors, rules);
                     }
-                    return new tree.Ruleset(selectors, rules);
                 } else {
                     // Backtrack
                     restore();

--- a/lib/carto/tree/reference.js
+++ b/lib/carto/tree/reference.js
@@ -121,9 +121,7 @@ tree.Reference.requiredProperties = function(symbolizer_name, rules) {
     }
 };
 
-/**
- * TODO: finish implementation - this is dead code
- */
+// TODO: finish implementation - this is dead code
 tree.Reference._validateValue = {
     'font': function(env, value) {
         if (env.validation_data && env.validation_data.fonts) {

--- a/lib/carto/tree/ruleset.js
+++ b/lib/carto/tree/ruleset.js
@@ -9,7 +9,8 @@ tree.Ruleset = function Ruleset(selectors, rules) {
 };
 tree.Ruleset.prototype = {
     eval: function(env) {
-        var ruleset = new tree.Ruleset(this.selectors, this.rules.slice(0));
+        var i,
+            ruleset = new tree.Ruleset(this.selectors, this.rules.slice(0));
         ruleset.root = this.root;
 
         // push the current ruleset to the frames stack
@@ -17,7 +18,7 @@ tree.Ruleset.prototype = {
 
         // Evaluate imports
         if (ruleset.root) {
-            for (var i = 0; i < ruleset.rules.length; i++) {
+            for (i = 0; i < ruleset.rules.length; i++) {
                 if (ruleset.rules[i] instanceof tree.Import) {
                     Array.prototype.splice
                          .apply(ruleset.rules, [i, 1].concat(ruleset.rules[i].eval(env)));
@@ -26,7 +27,7 @@ tree.Ruleset.prototype = {
         }
 
         // Evaluate everything else
-        for (var i = 0, rule; i < ruleset.rules.length; i++) {
+        for (i = 0, rule; i < ruleset.rules.length; i++) {
             rule = ruleset.rules[i];
             ruleset.rules[i] = rule.eval ? rule.eval(env) : rule;
         }
@@ -71,7 +72,8 @@ tree.Ruleset.prototype = {
         this.rulesets().forEach(function(rule) {
             if (rule !== self) {
                 for (var j = 0; j < rule.selectors.length; j++) {
-                    if (match = selector.match(rule.selectors[j])) {
+                    match = selector.match(rule.selectors[j]);
+                    if (match) {
                         if (selector.elements.length > 1) {
                             Array.prototype.push.apply(rules, rule.find(
                                 new tree.Selector(null, null, selector.elements.slice(1)), self));
@@ -86,11 +88,11 @@ tree.Ruleset.prototype = {
         return this._lookups[key] = rules;
     },
     flatten: function(result, parents, env) {
-        var selectors = [];
+        var selectors = [], i;
         if (this.selectors.length === 0) {
             env.frames = env.frames.concat(this.rules);
         }
-        for (var i = 0; i < this.selectors.length; i++) {
+        for (i = 0; i < this.selectors.length; i++) {
             var child = this.selectors[i];
 
             // This is an invalid filterset.
@@ -135,20 +137,42 @@ tree.Ruleset.prototype = {
         }
 
         var rules = [];
-        for (var i = 0; i < this.rules.length; i++) {
+        for (i = 0; i < this.rules.length; i++) {
             var rule = this.rules[i];
 
             if (rule instanceof tree.Ruleset) {
                 rule.flatten(result, selectors, env);
             } else if (rule instanceof tree.Rule) {
-                rules.push(rule);
+                var sel = tree.Reference.selector(rule.name);
+                if (sel && sel.type === 'shorthand') {
+                    // Expand shorthand to fullhand
+                    var elements = tree.Reference.selector(rule.name).elements;
+                    if (elements.length !== rule.value.value[0].value.length) {
+                        return env.error({
+                            message: 'shorthand for ' + rule.name + ' has the wrong number of arguments.' +
+                                ' arguments are ' + elements.join(', '),
+                            index: rule.index,
+                            type: 'runtime',
+                            filename: rule.filename
+                        });
+                    }
+                    for (var e = 0; e < elements.length; e++) {
+                        var n = rule.clone();
+                        n.name = elements[e];
+                        // this is awful
+                        n.value = rule.value.value[0].value[e];
+                        rules.push(n);
+                    }
+                } else {
+                    rules.push(rule);
+                }
             } else if (rule instanceof tree.Invalid) {
                 env.error(rule);
             }
         }
 
         var index = rules.length ? rules[0].index : false;
-        for (var i = 0; i < selectors.length; i++) {
+        for (i = 0; i < selectors.length; i++) {
             // For specificity sort, use the position of the first rule to allow
             // defining attachments that are under current element as a descendant
             // selector.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "underscore": "~1.3.3",
-    "mapnik-reference": "~5.0.0",
+    "mapnik-reference": "https://github.com/mapnik/mapnik-reference/tarball/shorthand",
     "xml2js": "~0.1.13"
   },
   "devDependencies": {

--- a/test/rendering/shorthand.mml
+++ b/test/rendering/shorthand.mml
@@ -1,0 +1,14 @@
+{
+    "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+    "Stylesheet": [
+        "shorthand.mss"
+    ],
+    "Layer": [{
+        "name": "world",
+        "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+        "Datasource": {
+            "file": "http://tilemill-data.s3.amazonaws.com/test_data/shape_demo.zip",
+            "type": "shape"
+        }
+    }]
+}

--- a/test/rendering/shorthand.mss
+++ b/test/rendering/shorthand.mss
@@ -1,0 +1,5 @@
+#world {
+    text: 12 Helvetica;
+    text-name: [FOO];
+    line:1 #000;
+}

--- a/test/rendering/shorthand.result
+++ b/test/rendering/shorthand.result
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Map[]>
+<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" maximum-extent="-20037508.34,-20037508.34,20037508.34,20037508.34">
+
+
+<Style name="world" filter-mode="first" >
+  <Rule>
+    <TextSymbolizer size="12" face-name="Helvetica" ><![CDATA[[FOO]]]></TextSymbolizer>
+    <LineSymbolizer stroke-width="1" stroke="#000000" />
+  </Rule>
+</Style>
+<Layer name="world"
+  srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <StyleName>world</StyleName>
+    <Datasource>
+       <Parameter name="file"><![CDATA[[absolute path]]]></Parameter>
+       <Parameter name="type"><![CDATA[shape]]></Parameter>
+    </Datasource>
+  </Layer>
+
+</Map>


### PR DESCRIPTION
Relies on the shorthand branch of mapnik-reference. Includes a test in
shorthand.mml and should be entirely backwards-compatible. This will
require a new minor version of mapnik-reference.

Would love a quick review @ajashton and @springmeyer 

jist of the change:

```css
#world {
    text: 12 Helvetica;
    text-name: [FOO];
    line:1 #000;
}
```