### PR TITLE
Add support for "mapnik-geometry-type" in filters

### DIFF
--- a/lib/carto/tree/filter.js
+++ b/lib/carto/tree/filter.js
@@ -1,6 +1,13 @@
 (function(tree) {
 
 tree.Filter = function Filter(key, op, val, index, filename) {
+
+    // See https://github.com/mapbox/carto/issues/180
+    // TODO: use mapnik-reference for these conversion ?
+    if ( key == "mapnik-geometry-type" ) {
+      key = "mapnik::geometry_type"
+    }
+
     if (key.is) {
         this.key = key.value;
         this._key = key;


### PR DESCRIPTION
This is a simple implementation of support for `mapnik-geometry-type` use in filters.
See https://github.com/mapbox/carto/issues/180

I'm probably missing something about the use of variables (ie: should we allow a variable to _expand_ to "mapnik-gemetry-type" ? I suppose that part isn't implemented).

Also, this implementation doesn' t use any support of mapnik-reference
