### PR TITLE
fix carto to work as global node module

### DIFF
--- a/bin/carto
+++ b/bin/carto
@@ -2,7 +2,7 @@
 
 var path = require('path'),
     fs = require('fs'),
-    carto = require('carto'),
+    carto = require('../lib/carto'),
     url = require('url'),
     _ = require('underscore');
 


### PR DESCRIPTION
When installing carto with -g and executing the global carto bin, the required module carto can't be found.
I think the reason is: https://npmjs.org/doc/faq.html#I-installed-something-globally-but-I-can-t-require-it
The patch fixes it.
