### PR TITLE
don't overwrite maximum-extent when specified in mml

### DIFF
--- a/lib/carto/renderer.js
+++ b/lib/carto/renderer.js
@@ -191,7 +191,7 @@ carto.Renderer.prototype.render = function render(m, callback) {
     if(!map_properties['maximum-extent']) {
         properties += ' maximum-extent="-20037508.34,-20037508.34,20037508.34,20037508.34"';
     }
-console.error(map_properties);
+
     output.unshift(
         '<?xml version="1.0" ' +
         'encoding="utf-8"?>\n' +


### PR DESCRIPTION
Needed when working in different projections.
