### PR TITLE
Update xml2js dependency

### DIFF
--- a/bin/mml2json.js
+++ b/bin/mml2json.js
@@ -25,8 +25,8 @@ fs.readFile(process.argv[2], 'utf-8', function(err, data) {
     });
 
     function addAttributes(obj) {
-        if (obj['@']) for (var key in obj['@']) obj[key] = obj['@'][key];
-        delete obj['@'];
+        if (obj['$']) for (var key in obj['$']) obj[key] = obj['$'][key];
+        delete obj['$'];
         return obj;
     }
     
@@ -35,7 +35,10 @@ fs.readFile(process.argv[2], 'utf-8', function(err, data) {
         else return obj;
     }
 
-    var parser = new xml2js.Parser();
+    var parser = new xml2js.Parser({
+        explicitRoot: false,
+        explicitArray: false
+    });
     parser.addListener('end', function(json) {
         console.log(JSON.stringify(json, function(key, value) {
             if (!key) {
@@ -52,7 +55,7 @@ fs.readFile(process.argv[2], 'utf-8', function(err, data) {
             else if (key === 'Datasource') {
                 value = addAttributes(value);
                 value.Parameter.forEach(function(parameter) {
-                    value[parameter['@'].name] = parameter['#'];
+                    value[parameter['$'].name] = parameter['_'];
                 });
                 delete value.Parameter;
                 return value;

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "underscore": "~1.4.3",
     "mapnik-reference": "~5.0.3",
-    "xml2js": "~0.1.13",
+    "xml2js": "~0.2.4",
     "optimist": "~0.3.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated to use v0.2.x of xml2js, partly by updating to reflect changed defaults and partly by setting defaults back to match v0.1.x.
