### PR TITLE
fix #247

### DIFF
--- a/lib/carto/renderer.js
+++ b/lib/carto/renderer.js
@@ -52,7 +52,7 @@ carto.Renderer.prototype.renderMSS = function render(data, callback) {
         var bench_name = '\tStyle "'+style_name+'" (#'+k+') toXML';
         if (env.benchmark) console.time(bench_name);
         // env.effects can be modified by this call
-        output.push(carto.tree.StyleXML(style_name, rule.attachment, rule.rules, env));
+        output.push(carto.tree.StyleXML(style_name, rule.attachment, rule, env));
         if (env.benchmark) console.timeEnd(bench_name);
     }
     if (env.benchmark) console.timeEnd('Total Style generation');
@@ -130,7 +130,7 @@ carto.Renderer.prototype.render = function render(m, callback) {
             style_name = l.name + (rule.attachment !== '__default__' ? '-' + rule.attachment : '');
 
             // env.effects can be modified by this call
-            var styleXML = carto.tree.StyleXML(style_name, rule.attachment, rule.rules, env);
+            var styleXML = carto.tree.StyleXML(style_name, rule.attachment, rule, env);
 
             if (styleXML) {
                 output.push(styleXML);
@@ -276,38 +276,41 @@ function inheritDefinitions(definitions, env) {
     var inheritTime = +new Date();
     // definitions are ordered by specificity,
     // high (index 0) to low
-    var byFilter = {}, result = {}, current, previous, attachment;
+    var byAttachment = {}, byFilter = {};
+    var result = [];
+    var current, previous, attachment;
 
     definitions.forEach(function(d) {
         d.filters.ev(env);
-        if (!result[d.attachment]) {
-            result[d.attachment] = { rules: [], attachment: d.attachment };
-            byFilter[d.attachment] = { };
-        }
     });
 
     for (var i = 0; i < definitions.length; i++) {
-
         attachment = definitions[i].attachment;
         current = [definitions[i]];
-
+        if (!byAttachment[attachment]) {
+            byAttachment[attachment] = [];
+            byAttachment[attachment].attachment = attachment;
+            byFilter[attachment] = {};
+            result.push(byAttachment[attachment]);
+        }
         // Iterate over all subsequent rules.
         for (var j = i + 1; j < definitions.length; j++) {
             if (definitions[j].attachment === attachment) {
                 // Only inherit rules from the same attachment.
-                current = addRules(current, definitions[j], byFilter[attachment], env);
+                current = addRules(current, definitions[j], byFilter, env);
             }
         }
 
         for (var k = 0; k < current.length; k++) {
             byFilter[attachment][current[k].filters] = current[k];
-            result[attachment].rules.push(current[k]);
+            byAttachment[attachment].push(current[k]);
         }
     }
 
     if (env.benchmark) console.warn('Inheritance time: ' + ((new Date() - inheritTime)) + 'ms');
 
-    return _.values(result);
+    return result;
+
 }
 
 // Sort styles by the minimum index of their rules.


### PR DESCRIPTION
@tmcw - in your court to review/modify/merge.

This fixes #247 by rolling back the renderer.js code to the last working version of `inheritDefinitions` (previously called `inheritRules`). I don't understand why it fixes it but the new regression tests confirm it is fixed and all other tests pass (likely due to such little attachment test coverage as per #245).
