### PR TITLE
Allow custom map parameters

### DIFF
--- a/lib/carto/renderer.js
+++ b/lib/carto/renderer.js
@@ -162,6 +162,11 @@ carto.Renderer.prototype.render = function render(m, callback) {
         if (!v && v !== 0) return memo;
 
         switch (k) {
+        // Known skippable properties.
+        case 'srs':
+        case 'Layer':
+        case 'Stylesheet':
+            break;
         // Non URL-bound TileJSON properties.
         case 'bounds':
         case 'center':
@@ -186,6 +191,16 @@ carto.Renderer.prototype.render = function render(m, callback) {
         case 'interactivity':
             memo.push('  <Parameter name="interactivity_layer">' + v.layer + '</Parameter>');
             memo.push('  <Parameter name="interactivity_fields">' + v.fields + '</Parameter>');
+            break;
+        // Support any additional scalar properties.
+        default:
+            if ('string' === typeof v) {
+                memo.push('  <Parameter name="' + k + '"><![CDATA[' + v + ']]></Parameter>');
+            } else if ('number' === typeof v) {
+                memo.push('  <Parameter name="' + k + '">' + v + '</Parameter>');
+            } else if ('boolean' === typeof v) {
+                memo.push('  <Parameter name="' + k + '">' + v + '</Parameter>');
+            }
             break;
         }
         return memo;

--- a/test/rendering/issue_239.result
+++ b/test/rendering/issue_239.result
@@ -8,6 +8,8 @@
   <Parameter name="format">png</Parameter>
   <Parameter name="minzoom">0</Parameter>
   <Parameter name="maxzoom">22</Parameter>
+  <Parameter name="scale">1</Parameter>
+  <Parameter name="metatile">2</Parameter>
 </Parameters>
 
 

--- a/test/rendering/parameters.mml
+++ b/test/rendering/parameters.mml
@@ -15,7 +15,10 @@
         "layer": "world",
         "fields": ["NAME"]
     },
-    "omitted": "Omitted property.",
+    "customString": "Hello world",
+    "customNumber": 5,
+    "customBoolean": true,
+    "customOmitted": { "foo": "bar" },
     "Stylesheet": [],
     "Layer": [{
         "name": "world",

--- a/test/rendering/parameters.result
+++ b/test/rendering/parameters.result
@@ -15,6 +15,9 @@
     <Parameter name="format">png</Parameter>
     <Parameter name="interactivity_layer">world</Parameter>
     <Parameter name="interactivity_fields">NAME</Parameter>
+    <Parameter name="customString"><![CDATA[Hello world]]></Parameter>
+    <Parameter name="customNumber">5</Parameter>
+    <Parameter name="customBoolean">true</Parameter>
 </Parameters>
 </Map>
 


### PR DESCRIPTION
Custom map parameters are not used by mapnik but are instead exposed for application/use-case specific needs. As such, this branch removes the cautious filtering of MML keys from making their way into custom map parameters, allowing application or use-case specific values to be rendered into the final XML.
