### PR TITLE
symbolizersToXML: Do not assume tagcontent has a value

### DIFF
--- a/lib/carto/tree/definition.js
+++ b/lib/carto/tree/definition.js
@@ -140,7 +140,7 @@ tree.Definition.prototype.symbolizersToXML = function(env, symbolizers, zoom) {
         if (selfclosing) {
             xml += '/>\n';
         } else {
-            if (tagcontent.indexOf('<') != -1) {
+            if (tagcontent && tagcontent.indexOf('<') != -1) {
                 xml += '>' + tagcontent + '</' + name + '>\n';
             } else {
                 xml += '><![CDATA[' + tagcontent + ']]></' + name + '>\n';

--- a/test/errorhandling/issue297.mss
+++ b/test/errorhandling/issue297.mss
@@ -1,0 +1,4 @@
+#t {
+  text-name: invalid;
+  text-face-name: "Dejagnu";
+}

--- a/test/errorhandling/issue297.result
+++ b/test/errorhandling/issue297.result
@@ -1,0 +1,1 @@
+issue297.mss:2:2 Invalid value for text-name, the type expression is expected. invalid (of type keyword)  was given.


### PR DESCRIPTION
Fixes #297

Includes testcase
