### PR TITLE
Fix empty name value resulting in non closed tag

### DIFF
--- a/lib/carto/tree/definition.js
+++ b/lib/carto/tree/definition.js
@@ -139,7 +139,7 @@ tree.Definition.prototype.symbolizersToXML = function(env, symbolizers, zoom) {
         }
         if (selfclosing) {
             xml += '/>\n';
-        } else if (tagcontent) {
+        } else if (typeof tagcontent !== "undefined") {
             if (tagcontent.indexOf('<') != -1) {
                 xml += '>' + tagcontent + '</' + name + '>\n';
             } else {

--- a/test/rendering-mss/empty_name.mss
+++ b/test/rendering-mss/empty_name.mss
@@ -1,0 +1,6 @@
+#poi-point {
+    text-name: "";
+    text-face-name: "DejaVu Sans Book";
+    text-size: 10;
+    text-fill: chocolate;
+}

--- a/test/rendering-mss/empty_name.xml
+++ b/test/rendering-mss/empty_name.xml
@@ -1,0 +1,5 @@
+<Style name="style" filter-mode="first">
+  <Rule>
+    <TextSymbolizer face-name="DejaVu Sans Book" size="10" fill="#d2691e" ><![CDATA[]]></TextSymbolizer>
+  </Rule>
+</Style>


### PR DESCRIPTION
See https://github.com/mapbox/carto/commit/5938ebb6097809ecab103936cfd0100fb74f9755#commitcomment-4130230

When text-name value was empty, so tag was not closed.

If you wonder why one would ever use an empty value, here you have an example: https://github.com/hotosm/HDM-CartoCSS/blob/master/labels.mss#L286 :)

One test included for same price :)

Thanks!

Yohan
