### PR TITLE
check for millstone.drainpool only if -l flag is passed

### DIFF
--- a/bin/carto
+++ b/bin/carto
@@ -58,7 +58,7 @@ if (!existsSync(input)) {
 function compileMML(err, data) {
     // force drain the millstone download pool now
     // to ensure we can exit without waiting
-    if (millstone.drainPool) {
+    if (options.localize && millstone.drainPool) {
         millstone.drainPool(function() {});
     }
     if (err) {


### PR DESCRIPTION
Passing an .mml file to compile without the -l flag will cause carto to crash as millstone is undefined. We now check for this flag (localize) before checking millstone.drainPool
