### PR TITLE
[bug] text-face-names containing &s aren't escaped properly

### DIFF
--- a/test/rendering-mss/text-face-name-escaping.mss
+++ b/test/rendering-mss/text-face-name-escaping.mss
@@ -1,0 +1,4 @@
+#layer {
+   text-name: [name];
+   text-face-name: "El&Font Bubble Regular";
+}

--- a/test/rendering-mss/text-face-name-escaping.xml
+++ b/test/rendering-mss/text-face-name-escaping.xml
@@ -1,0 +1,5 @@
+<Style name="style" filter-mode="first">
+  <Rule>
+    <TextSymbolizer face-name="El&amp;Font Bubble Regular" ><![CDATA[[name]]]></TextSymbolizer>
+  </Rule>
+</Style>


### PR DESCRIPTION
http://www.dafont.com/el-font-bubble.font is called "El&Font Bubble Regular".  However, when using that name, Mapnik fails to load it because the value in the resulting stylesheet isn't escaped.

Returning `xmlvalue` in `tree.Quoted#toString()` (vs. `this.value`) seems like it would work, but it breaks various other tests and doesn't seem quite right.
