### PR TITLE
Check if Stylesheet has an absolute filepath

### DIFF
--- a/bin/carto
+++ b/bin/carto
@@ -165,7 +165,8 @@ if (ext == '.mml') {
             if (typeof x !== 'string') {
                 return { id: x, data: x.data }
             }
-            return { id: x, data: fs.readFileSync(path.join(path.dirname(input), x), 'utf8') }
+            var absx = x[0] != '/' ? path.join(path.dirname(input), x) : x;
+            return { id: x, data: fs.readFileSync(absx , 'utf8') }
         });
         compileMML(null,data);
     }


### PR DESCRIPTION
This had me bugged after upgrading from a quite old version of carto : with millstone off by default, stylesheet resources referenced by their absolute path would be prefixed by input's dirname, therefore creating a wrong path.

As a workaround, enabling millstone would bring back the expected behavior.

This small patch on bin/carto allowed me to pass absolute stylesheet filenames without relying on millstone.