### PR TITLE
Support per-layer buffer-size

### DIFF
--- a/lib/carto/tree/layer.js
+++ b/lib/carto/tree/layer.js
@@ -22,6 +22,7 @@ tree.LayerXML = function(obj, styles) {
         ' name="' + obj.name + '"\n' +
         prop_string +
         ((typeof obj.status === 'undefined') ? '' : '  status="' + obj.status + '"\n') +
+        ((typeof obj['buffer-size'] === 'undefined') ? '' : '  buffer-size="' + obj['buffer-size'] + '"\n') +
         ((typeof obj.srs === 'undefined') ? '' : '  srs="' + obj.srs + '"') + '>\n    ' +
         styles.reverse().map(function(s) {
             return '<StyleName>' + s + '</StyleName>';


### PR DESCRIPTION
mapnik-reference details per-layer buffer-size, but Carto doesn't write it into the compiled XML
