### PR TITLE
adds support for browserify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,6 @@
 
 expresso = ./node_modules/.bin/mocha
 BROWSERIFY = ./node_modules/.bin/browserify
-TREE_FILES = $(shell ls ./lib/carto/tree/*.js)
-
-# generates the requirement options for browserify for modules loaded dinamically (see, lib/carto/index.js)
-BROWSERIFY_REQUIRES = $(foreach var,$(TREE_FILES), -r $(var):$(subst .js,,$(subst ./lib/carto,.,$(var))))
 
 lint:
 	./node_modules/.bin/jshint lib/carto/*.js lib/carto/tree/*.js
@@ -25,7 +21,7 @@ check: test
 dist:
 	mkdir -p dist
 
-dist/carto.uncompressed.js: dist $(shell $(BROWSERIFY) --list lib/carto/index.js) $(TREE_FILES)
-	$(BROWSERIFY) --require $(BROWSERIFY_REQUIRES)  --debug lib/carto/index.js --standalone carto > $@
+dist/carto.uncompressed.js: dist $(shell $(BROWSERIFY) --list lib/carto/index.js)
+	$(BROWSERIFY) --debug lib/carto/index.js --standalone carto > $@
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@
 #
 
 expresso = ./node_modules/.bin/mocha
+BROWSERIFY = ./node_modules/.bin/browserify
+TREE_FILES = $(shell ls ./lib/carto/tree/*.js)
+
+# generates the requirement options for browserify for modules loaded dinamically (see, lib/carto/index.js)
+BROWSERIFY_REQUIRES = $(foreach var,$(TREE_FILES), -r $(var):$(subst .js,,$(subst ./lib/carto,.,$(var))))
 
 lint:
 	./node_modules/.bin/jshint lib/carto/*.js lib/carto/tree/*.js
@@ -16,5 +21,11 @@ test:
 endif
 
 check: test
+
+dist:
+	mkdir -p dist
+
+dist/carto.uncompressed.js: dist $(shell $(BROWSERIFY) --list lib/carto/index.js) $(TREE_FILES)
+	$(BROWSERIFY) --require $(BROWSERIFY_REQUIRES)  --debug lib/carto/index.js --standalone carto > $@
 
 .PHONY: test

--- a/lib/carto/index.js
+++ b/lib/carto/index.js
@@ -4,7 +4,9 @@ var util = require('util'),
 
 
 function getVersion() {
-    if (parseInt(process.version.split('.')[1], 10) > 4) {
+    if (typeof(this['window']) !== undefined) {
+        return require('../../package.json').version.split('.');
+    } else if (parseInt(process.version.split('.')[1], 10) > 4) {
         return require('../../package.json').version.split('.');
     } else {
         // older node

--- a/lib/carto/index.js
+++ b/lib/carto/index.js
@@ -66,15 +66,33 @@ var carto = {
     }
 };
 
-[ 'call', 'color', 'comment', 'definition', 'dimension',
-  'element', 'expression', 'filterset', 'filter', 'field',
-  'keyword', 'layer', 'literal', 'operation', 'quoted', 'imagefilter',
-  'reference', 'rule', 'ruleset', 'selector', 'style', 'url', 'value',
-  'variable', 'zoom', 'invalid', 'fontset'
-].forEach(function(n) {
-    require('./tree/' +  n);
-});
-
+require('./tree/call');
+require('./tree/color');
+require('./tree/comment');
+require('./tree/definition');
+require('./tree/dimension');
+require('./tree/element');
+require('./tree/expression');
+require('./tree/filterset');
+require('./tree/filter');
+require('./tree/field');
+require('./tree/keyword');
+require('./tree/layer');
+require('./tree/literal');
+require('./tree/operation');
+require('./tree/quoted');
+require('./tree/imagefilter');
+require('./tree/reference');
+require('./tree/rule');
+require('./tree/ruleset');
+require('./tree/selector');
+require('./tree/style');
+require('./tree/url');
+require('./tree/value');
+require('./tree/variable');
+require('./tree/zoom');
+require('./tree/invalid');
+require('./tree/fontset');
 require('./functions');
 
 for (var k in carto) { exports[k] = carto[k]; }

--- a/lib/carto/index.js
+++ b/lib/carto/index.js
@@ -4,7 +4,7 @@ var util = require('util'),
 
 
 function getVersion() {
-    if (typeof(this['window']) !== undefined) {
+    if (process.browser) {
         return require('../../package.json').version.split('.');
     } else if (parseInt(process.version.split('.')[1], 10) > 4) {
         return require('../../package.json').version.split('.');

--- a/lib/carto/tree/reference.js
+++ b/lib/carto/tree/reference.js
@@ -5,6 +5,7 @@
 (function(tree) {
 
 var _ = require('underscore'),
+    mapnik_reference = require('mapnik-reference'),
     ref = {};
 
 ref.setData = function(data) {
@@ -23,7 +24,6 @@ ref.setData = function(data) {
 };
 
 ref.setVersion = function(version) {
-    var mapnik_reference = require('mapnik-reference');
     if (mapnik_reference.version.hasOwnProperty(version)) {
         ref.setData(mapnik_reference.version[version]);
         return true;

--- a/lib/carto/tree/reference.js
+++ b/lib/carto/tree/reference.js
@@ -5,7 +5,6 @@
 (function(tree) {
 
 var _ = require('underscore'),
-    mapnik_reference = require('mapnik-reference'),
     ref = {};
 
 ref.setData = function(data) {
@@ -24,6 +23,7 @@ ref.setData = function(data) {
 };
 
 ref.setVersion = function(version) {
+    var mapnik_reference = require('mapnik-reference');
     if (mapnik_reference.version.hasOwnProperty(version)) {
         ref.setData(mapnik_reference.version[version]);
         return true;

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "jshint": "0.2.x",
     "sax": "0.1.x",
     "istanbul": "~0.2.14",
-    "coveralls": "~2.10.1"
+    "coveralls": "~2.10.1",
+    "browserify": "~7.0.0"
   },
   "scripts": {
     "pretest": "npm install",


### PR DESCRIPTION
adds support for browserify, the final javascript file can be generated using make target:

```
make dist/carto.uncompressed.js
```



It exposes the global variable "carto" so can be used in the browser like:

```
carto.Parser().parse('#test { marker-fill: #F00; }')
```

One of the problems is mapnik reference, the module is not read to work with browserify since it loads modules dynamically. It does not make sense to make it compatible since mapnik-reference is not going to be used so people must to set the reference needed before parse/render:

carto.tree.Reference.setData(reference)

this PR also changes some code to make compatible with the browser. 