### PR TITLE
Add style folding optimization

### DIFF
--- a/lib/carto/renderer.js
+++ b/lib/carto/renderer.js
@@ -123,7 +123,7 @@ carto.Renderer.prototype.render = function render(m) {
         sorted = sortStyles(rules, env);
 
         for (var k = 0, rule, style_name; k < sorted.length; k++) {
-            rule = sorted[k];
+            rule = foldStyle(sorted[k]);
             style_name = l.name + (rule.attachment !== '__default__' ? '-' + rule.attachment : '');
 
             // env.effects can be modified by this call
@@ -353,6 +353,19 @@ function sortStyles(styles, env) {
     var result = styles.slice();
     result.sort(sortStylesIndex);
     return result;
+}
+
+// Removes dead style definitions that can never be reached
+// when filter-mode="first". The style is modified in-place
+// and returned. The style must be sorted.
+function foldStyle(style) {
+    for (var i = 0; i < style.length; i++) {
+        for (var j = style.length - 1; j > i; j--) {
+            if (style[j].filters.cloneWith(style[i].filters) === null)
+                style.splice(j, 1);
+        }
+    }
+    return style;
 }
 
 /**

--- a/lib/carto/tree/filterset.js
+++ b/lib/carto/tree/filterset.js
@@ -84,7 +84,7 @@ tree.Filterset.prototype.addable = function(filter) {
     var key = filter.key.toString(),
         value = filter.val.toString();
 
-    if (value.match(/^[0-9]+(\.[0-9]*)?$/)) value = parseFloat(value);
+    if (value.match(/^[+-]?[0-9]+(\.[0-9]*)?$/)) value = parseFloat(value);
 
     switch (filter.op) {
         case '=':

--- a/test/rendering/style_fold.mml
+++ b/test/rendering/style_fold.mml
@@ -1,0 +1,11 @@
+{
+  "Layer": [
+    {
+      "name": "a",
+      "id": "a"
+    }
+  ],
+  "Stylesheet": [
+    "style_fold.mss"
+  ]
+}

--- a/test/rendering/style_fold.mss
+++ b/test/rendering/style_fold.mss
@@ -1,0 +1,14 @@
+Map { }
+#a {
+  [x = 'X'] {
+    #a {
+      line-cap: round;
+    }
+  }
+  [y = 'Y'] {
+    line-width: 2;
+    #a {
+      line-cap: round;
+    }
+  }
+}

--- a/test/rendering/style_fold.result
+++ b/test/rendering/style_fold.result
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Map[]>
+<Map>
+
+
+<Style name="a" filter-mode="first">
+  <Rule>
+    <Filter>([y] = 'Y')</Filter>
+    <LineSymbolizer stroke-linecap="round" stroke-width="2" />
+  </Rule>
+  <Rule>
+    <Filter>([x] = 'X')</Filter>
+    <LineSymbolizer stroke-linecap="round" />
+  </Rule>
+</Style>
+<Layer name="a"
+>
+    <StyleName>a</StyleName>  </Layer>
+
+</Map>


### PR DESCRIPTION
Carto will generate XML like:
```
  <Rule>
    <Filter>([y] = 'Y')</Filter>
    <LineSymbolizer stroke-linecap="round" stroke-width="2" />
  </Rule>
  <Rule>
    <Filter>([y] = 'Y') and ([x] = 'X')</Filter>
    <LineSymbolizer stroke-width="2" stroke-linecap="round" />
  </Rule>
```
But the second Rule is dead. This pull request prunes such Rules. It also fixes bug with negative numbers in filters.