### PR TITLE
Update underscore dependency to 1.8.3

### DIFF
--- a/lib/carto/parser.js
+++ b/lib/carto/parser.js
@@ -128,7 +128,7 @@ carto.Parser = function Parser(env) {
         for (var n = err.index; n >= 0 && einput.charAt(n) !== '\n'; n--) {
             err.column++;
         }
-        return new Error(_('<%=filename%>:<%=line%>:<%=column%> <%=message%>').template(err));
+        return new Error(_.template('<%=filename%>:<%=line%>:<%=column%> <%=message%>')(err));
     }
 
     this.env = env = env || {};

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "node": ">=0.4.x"
   },
   "dependencies": {
-    "underscore": "~1.6.0",
+    "underscore": "~1.8.3",
     "mapnik-reference": "~8.5.0",
     "optimist": "~0.6.0"
   },


### PR DESCRIPTION
This requires a fix to the code due to a change in the semantics of `_.template` in the 1.7.0 release.