### PR TITLE
add support for YAML MML files

### DIFF
--- a/bin/carto
+++ b/bin/carto
@@ -4,7 +4,8 @@ var path = require('path'),
     fs = require('fs'),
     carto = require('../lib/carto'),
     url = require('url'),
-    _ = require('underscore');
+    _ = require('underscore'),
+    yaml = require('js-yaml');
 
 var existsSync = require('fs').existsSync || require('path').existsSync
 
@@ -125,7 +126,7 @@ try {
 
 if (ext == '.mml') {
     try {
-        data = JSON.parse(data);
+        data = yaml.safeLoad(data);
     } catch(err) {
         console.error("carto: " + err.message.replace(/^[A-Z]+, /, ''));
         process.exit(1);

--- a/package.json
+++ b/package.json
@@ -42,11 +42,12 @@
     "optimist": "~0.6.0"
   },
   "devDependencies": {
-    "mocha": "1.12.x",
-    "jshint": "0.2.x",
-    "sax": "0.1.x",
+    "coveralls": "~2.10.1",
     "istanbul": "~0.2.14",
-    "coveralls": "~2.10.1"
+    "js-yaml": "^3.4.6",
+    "jshint": "0.2.x",
+    "mocha": "1.12.x",
+    "sax": "0.1.x"
   },
   "scripts": {
     "pretest": "npm install",


### PR DESCRIPTION
Fixes #401.

I'm not sure if this is a too naive approach, but I tested with openstreetmap-carto project files and both json mml and yaml mml worked. The produced xml was identical except for the sequence of some parameters.