### PR TITLE
support Mapnik 3.x minimum-/maximum-scale-denominator for layers

### DIFF
--- a/lib/carto/tree/layer.js
+++ b/lib/carto/tree/layer.js
@@ -9,10 +9,14 @@ tree.LayerXML = function(obj, styles) {
 
     var prop_string = '';
     for (var prop in obj.properties) {
-        if (prop === 'minzoom') {
+        if (prop === 'minzoom') { // deprecated in Mapnik 3.x
             prop_string += '  maxzoom="' + tree.Zoom.ranges[obj.properties[prop]] + '"\n';
-        } else if (prop === 'maxzoom') {
+        } else if (prop === 'maxzoom') { // deprecated in Mapnik 3.x
             prop_string += '  minzoom="' + tree.Zoom.ranges[obj.properties[prop]+1] + '"\n';
+        } else if (prop === 'min-zoomlevel') {
+            prop_string += '  maximum-scale-denominator="' + tree.Zoom.ranges[obj.properties[prop]] + '"\n';
+        } else if (prop === 'max-zoomlevel') {
+            prop_string += '  minimum-scale-denominator="' + tree.Zoom.ranges[obj.properties[prop]+1] + '"\n';
         } else {
             prop_string += '  ' + prop + '="' + obj.properties[prop] + '"\n';
         }


### PR DESCRIPTION
Fixes #394.

How should the properties be named? I currently used `min-zoomlevel` and `max-zoomlevel`, because the old minzoom and maxzoom have to be kept for backwards compatibility and min-zoom, max-zoom are too close to the other names (only 1 character is different).