### PR TITLE
Replace old optimist ref

### DIFF
--- a/bin/carto
+++ b/bin/carto
@@ -23,7 +23,7 @@ var yargs = require('yargs')
 var options = yargs.argv;
 
 if (options.help) {
-    optimist.showHelp();
+    yargs.showHelp();
     process.exit(0);
 }
 


### PR DESCRIPTION
Changed missed old `optimist` reference to actual `yargs`.