### PR TITLE
fix wording on marker-opacity

### DIFF
--- a/docs/latest.md
+++ b/docs/latest.md
@@ -453,7 +453,7 @@ A file that this marker shows at each placement. If no file is given, the marker
 Default Value: 1
 _(The stroke-opacity and fill-opacity of the marker.)_
 
-The overall opacity of the marker, if set, overrides both the opacity of both the fill and stroke.
+The overall opacity of the marker, if set, overrides both the opacity of the fill and the opacity of the stroke.
 * * *
 
 ##### marker-fill-opacity `float`


### PR DESCRIPTION
Fixed a grammar issue that could potentially cause some confusion for the `marker-opacity` definition.

From:

 > overrides both the opacity of both the fill and stroke.

To:

 > overrides both the opacity of the fill and the opacity of the stroke.