### PR TITLE
add possibility of global _properties object in MML

### DIFF
--- a/lib/carto/renderer.js
+++ b/lib/carto/renderer.js
@@ -158,6 +158,16 @@ carto.Renderer.prototype.render = function render(m) {
             }
         }
 
+        // if there is a global _properties object for this layer take it into account
+        if (_.has(m, '_properties') && _.has(m._properties, l.layerId)) {
+            if (!_.has(l, 'properties')) {
+                l.properties = {};
+            }
+            var props = {};
+            _.assign(props, m._properties[l.layerId], l.properties);
+            l.properties = props;
+        }
+
         output.push(carto.tree.LayerXML(l, styles));
     }
 

--- a/test/rendering/issue_450.mml
+++ b/test/rendering/issue_450.mml
@@ -1,0 +1,67 @@
+{
+  "_properties": {
+    "global-properties": {
+      "group-by": "layer"
+    },
+    "override-properties": {
+      "group-by": "layer"
+    }
+  },
+  "bounds": [
+    -180,
+    -85.05112877980659,
+    180,
+    85.05112877980659
+  ],
+  "center": [
+    0,
+    0,
+    2
+  ],
+  "format": "png",
+  "interactivity": false,
+  "minzoom": 0,
+  "maxzoom": 22,
+  "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+  "Stylesheet": [
+  ],
+  "Layer": [
+    {
+      "id": "properties",
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "geometry": "polygon",
+      "Datasource": {
+        "file": "http://mapbox-geodata.s3.amazonaws.com/natural-earth-1.4.0/cultural/10m-admin-0-countries.zip",
+        "type": "shape"
+      },
+      "properties": {
+        "group-by": "layer"
+      }
+    },
+    {
+      "id": "global-properties",
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "geometry": "polygon",
+      "Datasource": {
+        "file": "http://mapbox-geodata.s3.amazonaws.com/natural-earth-1.4.0/cultural/10m-admin-0-countries.zip",
+        "type": "shape"
+      }
+    },
+    {
+      "id": "override-properties",
+      "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
+      "geometry": "polygon",
+      "Datasource": {
+        "file": "http://mapbox-geodata.s3.amazonaws.com/natural-earth-1.4.0/cultural/10m-admin-0-countries.zip",
+        "type": "shape"
+      },
+      "properties": {
+        "group-by": "override"
+      }
+    }
+  ],
+  "scale": 1,
+  "metatile": 2,
+  "name": "",
+  "description": ""
+}

--- a/test/rendering/issue_450.result
+++ b/test/rendering/issue_450.result
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Map[]>
+<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+
+<Parameters>
+  <Parameter name="bounds">-180,-85.05112877980659,180,85.05112877980659</Parameter>
+  <Parameter name="center">0,0,2</Parameter>
+  <Parameter name="format">png</Parameter>
+  <Parameter name="minzoom">0</Parameter>
+  <Parameter name="maxzoom">22</Parameter>
+  <Parameter name="scale">1</Parameter>
+  <Parameter name="metatile">2</Parameter>
+</Parameters>
+
+
+<Layer name="properties"
+  srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over"
+  group-by="layer">
+    <Datasource>
+       <Parameter name="file">[absolute path]</Parameter>
+       <Parameter name="type"><![CDATA[shape]]></Parameter>
+    </Datasource>
+  </Layer>
+<Layer name="global-properties"
+    srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over"
+    group-by="layer">
+      <Datasource>
+         <Parameter name="file">[absolute path]</Parameter>
+         <Parameter name="type"><![CDATA[shape]]></Parameter>
+      </Datasource>
+    </Layer>
+<Layer name="override-properties"
+    srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over"
+    group-by="override">
+      <Datasource>
+         <Parameter name="file">[absolute path]</Parameter>
+         <Parameter name="type"><![CDATA[shape]]></Parameter>
+      </Datasource>
+    </Layer>
+
+</Map>


### PR DESCRIPTION
References layers and their properties
fixes #450

I'm not yet sure which properties definition should be more important. Currently if both `_properties` and `properties` for a layer contain the same property `properties` wins. This cannot happen with TM2, but it is necessary to specify for carto.

@pnorman please try it out if it works for you.
cc @gravitystorm 