### PR TITLE
Fix linting

### DIFF
--- a/test/support/.eslintrc.yml
+++ b/test/support/.eslintrc.yml
@@ -1,0 +1,2 @@
+rules:
+  no-control-regex: 0


### PR DESCRIPTION
Addresses https://github.com/mapbox/carto/issues/489.

The linting in Travis fails due to `no-control-regex` rule on this line:
https://github.com/mapbox/carto/blob/611a498188b7bb831c83a2808fb063b3597a03f9/test/support/diff.js#L58

That regex contains ASCII control characters in `\u0000-\u0040`. I think it's just fine in the test, so I suppressed that rule.

cc @nebulon42 

