### PR TITLE
CI: remove Node 6 and add Node 12 and 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ language: node_js
 sudo: false
 
 node_js:
+  - "14"
+  - "13"
+  - "12"
   - "11"
   - "10"
   - "8"
-  - "6"
 
 script:
   - npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,10 @@
 # Test against this versions of Node.js
 environment:
   matrix:
+    - nodejs_version: 14
+    - nodejs_version: 12
     - nodejs_version: 10
     - nodejs_version: 8
-    - nodejs_version: 6
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/lib/carto/parser.js
+++ b/lib/carto/parser.js
@@ -247,6 +247,7 @@ carto.Parser = function Parser(env) {
             // If the specifity is equal, the definition is compared by the elements
             // array. Definitions with more elements are 'larger', and definitions
             // with the same number of elements are sorted alphabetically.
+            // If the elements are also equal, the zoom level of the definition is compared
             //
             // Written to be used as a .sort(Function);
             // argument.
@@ -262,15 +263,16 @@ carto.Parser = function Parser(env) {
                 if (bs[3] != as[3]) return bs[3] - as[3];
 
                 // The definition with the most elements is 'larger'
-                if (a.elements.length != b.elements.length) {
-                    return b.elements.length - a.elements.length;
-                }
+                if (a.elements.length != b.elements.length) return b.elements.length - a.elements.length;
+
+                // Sort based on the alphabetic order of each element
                 for (var i = 0; i < a.elements.length; i++) {
-                    // Sort based on the alphabetic order of each element
                     if (a.elements[i] != b.elements[i]) {
-                        return a.elements[i].value.localeCompare(b.elements[i].value)
+                        return a.elements[i].value.localeCompare(b.elements[i].value);
                     }
                 }
+
+                if (a.zoom != b.zoom) return b.zoom - a.zoom;
 
                 // Order is not defined
                 return 0;

--- a/lib/carto/parser.js
+++ b/lib/carto/parser.js
@@ -256,7 +256,16 @@ carto.Parser = function Parser(env) {
                 if (as[0] != bs[0]) return bs[0] - as[0];
                 if (as[1] != bs[1]) return bs[1] - as[1];
                 if (as[2] != bs[2]) return bs[2] - as[2];
-                return bs[3] - as[3];
+                if (bs[3] != as[3]) return bs[3] - as[3];
+
+                if (b.__order__  !== undefined && a.__order__ !== undefined) {
+                    // Default to the original order in the array
+                    // This is required for pre-version-8 and post-version-10 Node compatibility
+                    return b.__order__ - a.__order__;
+                }
+
+                // Order is not defined
+                return 0;
             };
 
             return root;

--- a/lib/carto/parser.js
+++ b/lib/carto/parser.js
@@ -244,6 +244,9 @@ carto.Parser = function Parser(env) {
 
             // Sort rules by specificity: this function expects selectors to be
             // split already.
+            // If the specifity is equal, the definition is compared by the elements
+            // array. Definitions with more elements are 'larger', and definitions
+            // with the same number of elements are sorted alphabetically.
             //
             // Written to be used as a .sort(Function);
             // argument.
@@ -258,10 +261,15 @@ carto.Parser = function Parser(env) {
                 if (as[2] != bs[2]) return bs[2] - as[2];
                 if (bs[3] != as[3]) return bs[3] - as[3];
 
-                if (b.__order__  !== undefined && a.__order__ !== undefined) {
-                    // Default to the original order in the array
-                    // This is required for pre-version-8 and post-version-10 Node compatibility
-                    return b.__order__ - a.__order__;
+                // The definition with the most elements is 'larger'
+                if (a.elements.length != b.elements.length) {
+                    return b.elements.length - a.elements.length;
+                }
+                for (var i = 0; i < a.elements.length; i++) {
+                    // Sort based on the alphabetic order of each element
+                    if (a.elements[i] != b.elements[i]) {
+                        return a.elements[i].value.localeCompare(b.elements[i].value)
+                    }
                 }
 
                 // Order is not defined

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "man": "./man/carto.1",
   "main": "./lib/carto/index",
   "engines": {
-    "node": ">=0.5.x"
+    "node": ">=8.0.0"
   },
   "dependencies": {
     "chroma-js": "~1.3.5",

--- a/test/rendering/fontset-duplication.result
+++ b/test/rendering/fontset-duplication.result
@@ -1,5228 +1,5223 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE Map[]>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" >
-
-<FontSet name="fontset-0">
-  <Font face-name="Franklin Gothic FS Medium"/>
-  <Font face-name="DejaVu Sans Book"/>
-</FontSet>
-<FontSet name="fontset-1">
-  <Font face-name="Franklin Gothic FS Book"/>
-  <Font face-name="DejaVu Sans Book"/>
-</FontSet>
-<Style name="city" filter-mode="first">
-  <Rule>
-    <MaxScaleDenominator>400000</MaxScaleDenominator>
-    <Filter>([SCALERANK] = 10)</Filter>
-    <TextSymbolizer size="14" character-spacing="1" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>750000</MaxScaleDenominator>
-    <MinScaleDenominator>400000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 10)</Filter>
-    <TextSymbolizer size="13" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>1500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 10)</Filter>
-    <TextSymbolizer size="12" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>3000000</MaxScaleDenominator>
-    <MinScaleDenominator>1500000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 10)</Filter>
-    <TextSymbolizer fontset-name="fontset-0" size="10" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>400000</MaxScaleDenominator>
-    <Filter>([SCALERANK] = 9)</Filter>
-    <TextSymbolizer size="14" character-spacing="1" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>750000</MaxScaleDenominator>
-    <MinScaleDenominator>400000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 9)</Filter>
-    <TextSymbolizer size="13" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>1500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 9)</Filter>
-    <TextSymbolizer size="13" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>3000000</MaxScaleDenominator>
-    <MinScaleDenominator>1500000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 9)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>400000</MaxScaleDenominator>
-    <Filter>([SCALERANK] = 8)</Filter>
-    <TextSymbolizer size="14" character-spacing="1" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>750000</MaxScaleDenominator>
-    <MinScaleDenominator>400000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 8)</Filter>
-    <TextSymbolizer size="14" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>1500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 8)</Filter>
-    <TextSymbolizer size="13" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>3000000</MaxScaleDenominator>
-    <MinScaleDenominator>1500000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 8)</Filter>
-    <TextSymbolizer size="12" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>3000000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 8)</Filter>
-    <TextSymbolizer fontset-name="fontset-0" size="10" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>400000</MaxScaleDenominator>
-    <Filter>([SCALERANK] = 7)</Filter>
-    <TextSymbolizer size="15" character-spacing="2" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>750000</MaxScaleDenominator>
-    <MinScaleDenominator>400000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 7)</Filter>
-    <TextSymbolizer size="14" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>1500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 7)</Filter>
-    <TextSymbolizer size="14" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>3000000</MaxScaleDenominator>
-    <MinScaleDenominator>1500000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 7)</Filter>
-    <TextSymbolizer size="13" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>3000000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 7)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>400000</MaxScaleDenominator>
-    <Filter>([SCALERANK] = 6)</Filter>
-    <TextSymbolizer size="15" character-spacing="2" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>750000</MaxScaleDenominator>
-    <MinScaleDenominator>400000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 6)</Filter>
-    <TextSymbolizer size="15" character-spacing="1" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>1500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 6)</Filter>
-    <TextSymbolizer size="14" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>3000000</MaxScaleDenominator>
-    <MinScaleDenominator>1500000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 6)</Filter>
-    <TextSymbolizer size="13" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>3000000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-0" size="10" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>400000</MaxScaleDenominator>
-    <Filter>([SCALERANK] = 5)</Filter>
-    <TextSymbolizer size="15" character-spacing="2" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>750000</MaxScaleDenominator>
-    <MinScaleDenominator>400000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 5)</Filter>
-    <TextSymbolizer size="15" character-spacing="1" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>1500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 5)</Filter>
-    <TextSymbolizer size="15" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>3000000</MaxScaleDenominator>
-    <MinScaleDenominator>1500000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 5)</Filter>
-    <TextSymbolizer size="14" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>3000000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 5)</Filter>
-    <TextSymbolizer size="12" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>400000</MaxScaleDenominator>
-    <Filter>([SCALERANK] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="3" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>750000</MaxScaleDenominator>
-    <MinScaleDenominator>400000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 4)</Filter>
-    <TextSymbolizer size="15" character-spacing="1" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>1500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 4)</Filter>
-    <TextSymbolizer size="15" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>3000000</MaxScaleDenominator>
-    <MinScaleDenominator>1500000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 4)</Filter>
-    <TextSymbolizer size="14" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>3000000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 4)</Filter>
-    <TextSymbolizer size="13" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 4)</Filter>
-    <TextSymbolizer size="12" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>400000</MaxScaleDenominator>
-    <Filter>([SCALERANK] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="3" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>750000</MaxScaleDenominator>
-    <MinScaleDenominator>400000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>1500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 3)</Filter>
-    <TextSymbolizer size="16" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>3000000</MaxScaleDenominator>
-    <MinScaleDenominator>1500000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 3)</Filter>
-    <TextSymbolizer size="15" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>3000000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 3)</Filter>
-    <TextSymbolizer size="14" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 3)</Filter>
-    <TextSymbolizer size="13" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([SCALERANK] = 3)</Filter>
-    <TextSymbolizer size="12" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>400000</MaxScaleDenominator>
-    <Filter>([SCALERANK] &lt; 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="3" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>750000</MaxScaleDenominator>
-    <MinScaleDenominator>400000</MinScaleDenominator>
-    <Filter>([SCALERANK] &lt; 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>1500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([SCALERANK] &lt; 3)</Filter>
-    <TextSymbolizer size="16" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>3000000</MaxScaleDenominator>
-    <MinScaleDenominator>1500000</MinScaleDenominator>
-    <Filter>([SCALERANK] &lt; 3)</Filter>
-    <TextSymbolizer size="15" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>3000000</MinScaleDenominator>
-    <Filter>([SCALERANK] &lt; 3)</Filter>
-    <TextSymbolizer size="15" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([SCALERANK] &lt; 3)</Filter>
-    <TextSymbolizer size="14" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([SCALERANK] &lt; 3)</Filter>
-    <TextSymbolizer size="13" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([SCALERANK] &lt; 3)</Filter>
-    <TextSymbolizer size="12" fontset-name="fontset-0" fill="rgba(0, 0, 0, 0.6)" halo-radius="1" halo-fill="rgba(255, 255, 255, 0.4)" >[NAMEASCII]</TextSymbolizer>
-  </Rule>
-</Style>
-<Layer name="city"
-  srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
-    <StyleName>city</StyleName>
+<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+  <FontSet name="fontset-0">
+    <Font face-name="Franklin Gothic FS Medium" />
+    <Font face-name="DejaVu Sans Book" />
+  </FontSet>
+  <FontSet name="fontset-1">
+    <Font face-name="Franklin Gothic FS Book" />
+    <Font face-name="DejaVu Sans Book" />
+  </FontSet>
+  <Style filter-mode="first" name="city">
+    <Rule>
+      <MaxScaleDenominator>400000</MaxScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 10)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="14"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>750000</MaxScaleDenominator>
+      <MinScaleDenominator>400000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 10)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="13"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>1500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 10)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="12"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>3000000</MaxScaleDenominator>
+      <MinScaleDenominator>1500000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 10)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="10"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>400000</MaxScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 9)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="14"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>750000</MaxScaleDenominator>
+      <MinScaleDenominator>400000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 9)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="13"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>1500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 9)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="13"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>3000000</MaxScaleDenominator>
+      <MinScaleDenominator>1500000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 9)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="11"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>400000</MaxScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 8)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="14"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>750000</MaxScaleDenominator>
+      <MinScaleDenominator>400000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 8)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="14"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>1500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 8)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="13"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>3000000</MaxScaleDenominator>
+      <MinScaleDenominator>1500000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 8)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="12"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>3000000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 8)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="10"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>400000</MaxScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 7)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="15"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>750000</MaxScaleDenominator>
+      <MinScaleDenominator>400000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 7)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="14"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>1500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 7)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="14"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>3000000</MaxScaleDenominator>
+      <MinScaleDenominator>1500000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 7)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="13"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>3000000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 7)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="11"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>400000</MaxScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="15"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>750000</MaxScaleDenominator>
+      <MinScaleDenominator>400000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="15"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>1500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 6)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="14"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>3000000</MaxScaleDenominator>
+      <MinScaleDenominator>1500000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 6)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="13"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>3000000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 6)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="11"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 6)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="10"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>400000</MaxScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="15"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>750000</MaxScaleDenominator>
+      <MinScaleDenominator>400000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="15"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>1500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 5)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="15"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>3000000</MaxScaleDenominator>
+      <MinScaleDenominator>1500000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 5)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="14"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>3000000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 5)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="12"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 5)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="11"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>400000</MaxScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="3" fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="16"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>750000</MaxScaleDenominator>
+      <MinScaleDenominator>400000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="15"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>1500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 4)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="15"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>3000000</MaxScaleDenominator>
+      <MinScaleDenominator>1500000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 4)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="14"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>3000000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 4)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="13"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 4)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="12"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 4)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="11"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>400000</MaxScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="3" fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="16"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>750000</MaxScaleDenominator>
+      <MinScaleDenominator>400000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="16"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>1500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 3)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="16"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>3000000</MaxScaleDenominator>
+      <MinScaleDenominator>1500000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 3)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="15"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>3000000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 3)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="14"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 3)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="13"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] = 3)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="12"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>400000</MaxScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] < 3)]]></Filter>
+      <TextSymbolizer character-spacing="3" fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="16"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>750000</MaxScaleDenominator>
+      <MinScaleDenominator>400000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] < 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="16"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>1500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] < 3)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="16"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>3000000</MaxScaleDenominator>
+      <MinScaleDenominator>1500000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] < 3)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="15"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>3000000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] < 3)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="15"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] < 3)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="14"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] < 3)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="13"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([SCALERANK] < 3)]]></Filter>
+      <TextSymbolizer fill="rgba(0, 0, 0, 0.6)" fontset-name="fontset-0" halo-fill="rgba(255, 255, 255, 0.4)" halo-radius="1" size="12"><![CDATA[[NAMEASCII]]]></TextSymbolizer>
+    </Rule>
+  </Style>
+  <Layer name="city" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <StyleName><![CDATA[city]]></StyleName>
     <Datasource>
-       <Parameter name="file"><![CDATA[[absolute path]]]></Parameter>
-       <Parameter name="type"><![CDATA[shape]]></Parameter>
+      <Parameter name="file"><![CDATA[[absolute path]]]></Parameter>
+      <Parameter name="type"><![CDATA[shape]]></Parameter>
     </Datasource>
   </Layer>
-
-<Style name="country-label" filter-mode="first">
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_NAME] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ADMIN] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ADMIN]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5) and ([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[NAME]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_NAME] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 6)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 5)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 4)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 3)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <Filter>([Z_ABBREV] = 2)</Filter>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >[ABBREV]</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>6500000</MaxScaleDenominator>
-    <MinScaleDenominator>750000</MinScaleDenominator>
-    <TextSymbolizer size="16" character-spacing="2" line-spacing="4" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>12500000</MaxScaleDenominator>
-    <MinScaleDenominator>6500000</MinScaleDenominator>
-    <TextSymbolizer size="14" character-spacing="2" line-spacing="2" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>25000000</MaxScaleDenominator>
-    <MinScaleDenominator>12500000</MinScaleDenominator>
-    <TextSymbolizer size="12" character-spacing="1" line-spacing="1" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
-    <TextSymbolizer size="11" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
-    <TextSymbolizer size="9" fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>200000000</MaxScaleDenominator>
-    <MinScaleDenominator>100000000</MinScaleDenominator>
-    <TextSymbolizer fontset-name="fontset-1" fill="rgba(0, 0, 0, 0.5)" size="9" text-transform="uppercase" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" character-spacing="1" line-spacing="1" wrap-width="20" >''</TextSymbolizer>
-  </Rule>
-</Style>
-<Layer name="country-label"
-  srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
-    <StyleName>country-label</StyleName>
+  <Style filter-mode="first" name="country-label">
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ADMIN]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ADMIN] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5) and ([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6) and ([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[NAME]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_NAME] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 2)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 3)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 4)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 5)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA[[ABBREV]]]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <Filter><![CDATA[([Z_ABBREV] = 6)]]></Filter>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>6500000</MaxScaleDenominator>
+      <MinScaleDenominator>750000</MinScaleDenominator>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="4" size="16" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>12500000</MaxScaleDenominator>
+      <MinScaleDenominator>6500000</MinScaleDenominator>
+      <TextSymbolizer character-spacing="2" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="2" size="14" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>25000000</MaxScaleDenominator>
+      <MinScaleDenominator>12500000</MinScaleDenominator>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="12" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>50000000</MaxScaleDenominator>
+      <MinScaleDenominator>25000000</MinScaleDenominator>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="11" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>100000000</MaxScaleDenominator>
+      <MinScaleDenominator>50000000</MinScaleDenominator>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+    <Rule>
+      <MaxScaleDenominator>200000000</MaxScaleDenominator>
+      <MinScaleDenominator>100000000</MinScaleDenominator>
+      <TextSymbolizer character-spacing="1" fill="rgba(0, 0, 0, 0.5)" fontset-name="fontset-1" halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1" line-spacing="1" size="9" text-transform="uppercase" wrap-width="20"><![CDATA['']]></TextSymbolizer>
+    </Rule>
+  </Style>
+  <Layer name="country-label" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <StyleName><![CDATA[country-label]]></StyleName>
     <Datasource>
-       <Parameter name="file"><![CDATA[[absolute path]]]></Parameter>
-       <Parameter name="type"><![CDATA[shape]]></Parameter>
+      <Parameter name="file"><![CDATA[[absolute path]]]></Parameter>
+      <Parameter name="type"><![CDATA[shape]]></Parameter>
     </Datasource>
   </Layer>
-
 </Map>

--- a/test/rendering/zoomlevels.result
+++ b/test/rendering/zoomlevels.result
@@ -3,7 +3,7 @@
 <Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" >
 
 
-<Style name="world" filter-mode="first">
+<Style filter-mode="first" name="world">
   <Rule>
     <MaxScaleDenominator>750000</MaxScaleDenominator>
     <MinScaleDenominator>200000</MinScaleDenominator>
@@ -29,7 +29,7 @@
     </Datasource>
   </Layer>
 
-<Style name="countries" filter-mode="first">
+<Style filter-mode="first" name="countries">
   <Rule>
     <MaxScaleDenominator>100000</MaxScaleDenominator>
     <LineSymbolizer stroke-width="0.25" />
@@ -75,13 +75,13 @@
     <LineSymbolizer stroke-width="1" />
   </Rule>
   <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
+    <MaxScaleDenominator>50000000</MaxScaleDenominator>
+    <MinScaleDenominator>25000000</MinScaleDenominator>
     <LineSymbolizer stroke-width="1.25" />
   </Rule>
   <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
+    <MaxScaleDenominator>100000000</MaxScaleDenominator>
+    <MinScaleDenominator>50000000</MinScaleDenominator>
     <LineSymbolizer stroke-width="1.25" />
   </Rule>
   <Rule>

--- a/test/rendering/zoomlevels.result
+++ b/test/rendering/zoomlevels.result
@@ -75,13 +75,13 @@
     <LineSymbolizer stroke-width="1" />
   </Rule>
   <Rule>
-    <MaxScaleDenominator>50000000</MaxScaleDenominator>
-    <MinScaleDenominator>25000000</MinScaleDenominator>
+    <MaxScaleDenominator>100000000</MaxScaleDenominator>
+    <MinScaleDenominator>50000000</MinScaleDenominator>
     <LineSymbolizer stroke-width="1.25" />
   </Rule>
   <Rule>
-    <MaxScaleDenominator>100000000</MaxScaleDenominator>
-    <MinScaleDenominator>50000000</MinScaleDenominator>
+    <MaxScaleDenominator>50000000</MaxScaleDenominator>
+    <MinScaleDenominator>25000000</MinScaleDenominator>
     <LineSymbolizer stroke-width="1.25" />
   </Rule>
   <Rule>


### PR DESCRIPTION
The CI config for Travis and Appveyor have been upgraded. The Node versions were outdated, and current/modern versions were not being tested.

See https://nodejs.org/en/about/releases/

Node 8 is end of life (unmaintained), but I left it for some compatibility. It should be good to remove it if maintainers agree.

Node 10 is currently in maintanance mode.

Node 12 and 14 are the active and current versions. The Travis tests also contain versions 11 and 13 (non-LTS).