### PR TITLE
Fix and add tests for Rule#toString

### DIFF
--- a/lib/carto/tree/rule.js
+++ b/lib/carto/tree/rule.js
@@ -37,7 +37,7 @@ tree.Rule.prototype.updateID = function() {
 };
 
 tree.Rule.prototype.toString = function() {
-    return '[' + tree.Zoom.toString(this.zoom) + '] ' + this.name + ': ' + this.value;
+    return '[' + (this.zoom ? this.zoom.toString() : (new tree.Zoom()).toString()) + '] ' + this.name + ': ' + this.value;
 };
 
 tree.Rule.prototype.validate = function (env) {

--- a/test/rule.test.js
+++ b/test/rule.test.js
@@ -1,0 +1,16 @@
+var assert = require('assert');
+var tree = require('../lib/carto/tree.js');
+
+describe('Rule', function() {
+    describe('To string', function() {
+        it('with zoom', function() {
+            const rule = new tree.Rule(new tree.Reference(null), 'name', 'value', 'index', 'filename');
+            rule.zoom = (new tree.Zoom()).setZoom((1 << 2 | 1 << 3 | 1 << 4))
+            assert.equal(rule.toString(), '[..XXX.....................] name: value')
+        });
+        it('without zoom', function() {
+            const rule = new tree.Rule(new tree.Reference(null), 'name', 'value', 'index', 'filename');
+            assert.equal(rule.toString(), '[..........................] name: value')
+        });
+    });
+});


### PR DESCRIPTION
Fixes #503

The toString method was not called on a Zoom object but on the prototype.

Added test for two scenarios for toString of a Rule.