### PR TITLE
lib/carto/mml.js: FIX: Error: Function yaml.safeLoad is removed in js…

### DIFF
--- a/lib/carto/mml.js
+++ b/lib/carto/mml.js
@@ -22,7 +22,7 @@ carto.MML.prototype.load = function load(basedir, data, callback) {
         env = {};
 
     try {
-        mml = yaml.safeLoad(data);
+        mml = yaml.load(data);
     } catch (err) {
         env = {};
         util.error(env, {


### PR DESCRIPTION
…-yaml 4. Use yaml.load instead, which is now safe by default.

This makes the code compatible with js-yaml >= 4.