### PR TITLE
Attempt to support reading files ending in .yml

### DIFF
--- a/bin/carto
+++ b/bin/carto
@@ -67,7 +67,7 @@ try {
     process.exit(1);
 }
 
-if (ext === '.mml') {
+if (ext === '.mml' || ext === '.yml') {
     var mml = new carto.MML(options);
     mml.load(path.dirname(input), data, compile);
 } else if (ext === '.mss') {
@@ -93,7 +93,7 @@ function compile(err, data) {
     });
     try {
         var output;
-        if (ext === '.mml') {
+        if (ext === '.mml' || ext === '.yml') {
             output = renderer.render(data);
         } else if (ext === '.mss') {
             output = renderer.renderMSS(data);


### PR DESCRIPTION
If a style file ends in `.yml` (rather than `.mml`), `carto(1)` won't work on it, even though `.mml` files are YAML files.

With this (not very well tested) change, I think this makes carto read .yml files.